### PR TITLE
Lobby UI

### DIFF
--- a/ui/mods/scenario_lobby/scenario_lobby.html
+++ b/ui/mods/scenario_lobby/scenario_lobby.html
@@ -1,0 +1,51 @@
+<style>
+  .scenario_picker.bootstrap-select .dropdown-toggle.selectpicker {
+    padding: 8px;
+    border: 1px solid rgba(255,255,255,.3);
+  }
+
+  .section_subheader {
+    font-size: 13px;
+    color: #fff;
+    text-shadow: 0px 0px 20px #00b3ff;
+    padding: 8px 0px 0px;
+  }
+
+  #scenarioFilenameWrapper {
+    font-family: 'Droid Sans Mono';
+    font-size: 12px;
+  }
+</style>
+
+<div class="section scenario">
+  <div class="form-group">
+    <div class="section_header scenario">
+      Scenario
+    </div>
+
+    <select class="form-control scenario_picker" id="scenario-picker" onchange="model.setScenario(this.value)">
+    </select>
+
+    <div id="scenarioFilenameWrapper">
+      Loaded: <span id="scenarioFilename"></span>.json
+    </div>
+
+    <div id="scenarioDescriptionWrapper">
+      <div class="section_subheader scenario_description">
+        <loc>Description</loc>
+      </div>
+
+      <div id="scenarioDescription">
+      </div>
+    </div>
+
+    <div id="scenarioSetupWrapper">
+      <div class="section_subheader scenario_setup">
+        <loc>Setup</loc>
+      </div>
+
+      <div id="scenarioSetup">
+      </div>
+    </div>
+  </div>
+</div>

--- a/ui/mods/scenario_lobby/scenario_lobby.html
+++ b/ui/mods/scenario_lobby/scenario_lobby.html
@@ -15,6 +15,19 @@
     font-family: 'Droid Sans Mono';
     font-size: 12px;
   }
+
+  .rich_text ul,
+  .rich_text ol {
+    margin-left: 20px;
+  }
+
+  .rich_text ul {
+    list-style-type: square;
+  }
+
+  .rich_text li {
+    margin: 0 0 2px;
+  }
 </style>
 
 <div class="section scenario">
@@ -23,7 +36,11 @@
       Scenario
     </div>
 
-    <select class="form-control scenario_picker" id="scenario-picker" onchange="model.setScenario(this.value)">
+    <select
+      class="form-control scenario_picker"
+      id="scenario-picker"
+      onchange="model.setScenario(this.value)"
+    >
     </select>
 
     <div id="scenarioFilenameWrapper">
@@ -35,16 +52,16 @@
         <loc>Description</loc>
       </div>
 
-      <div id="scenarioDescription">
+      <div id="scenarioDescription" class="rich_text">
       </div>
     </div>
 
-    <div id="scenarioSetupWrapper">
+    <div id="scenarioSetupWrapper" data-bind="visible: canChangeSettings">
       <div class="section_subheader scenario_setup">
         <loc>Setup</loc>
       </div>
 
-      <div id="scenarioSetup">
+      <div id="scenarioSetup" class="rich_text">
       </div>
     </div>
   </div>

--- a/ui/mods/scenario_lobby/scenario_lobby.html
+++ b/ui/mods/scenario_lobby/scenario_lobby.html
@@ -49,7 +49,7 @@
 
     <div id="scenarioDescriptionWrapper">
       <div class="section_subheader scenario_description">
-        <loc>Description</loc>
+        Description
       </div>
 
       <div id="scenarioDescription" class="rich_text">
@@ -58,7 +58,7 @@
 
     <div id="scenarioSetupWrapper" data-bind="visible: canChangeSettings">
       <div class="section_subheader scenario_setup">
-        <loc>Setup</loc>
+        Setup Info
       </div>
 
       <div id="scenarioSetup" class="rich_text">

--- a/ui/mods/scenario_lobby/scenario_lobby.js
+++ b/ui/mods/scenario_lobby/scenario_lobby.js
@@ -27,7 +27,7 @@ var objectivesToActivate =  ko.observable(-1).extend({ session: 'activeObjective
 objectivesToActivate(-1)
 
 model.scenarioCommanderSpec = "";
-                              
+
 model.selectedCommanderSpec = ko.observable("/pa/units/commanders/raptor_rallus/raptor_rallus.json").extend({ session: 'selectedCommanderSpec' });
 
 model.selectedCommander = ko.computed(function () {
@@ -43,7 +43,7 @@ model.selectedCommander = ko.computed(function () {
             var commander = model.preferredCommander();
             if (_.has(commander, 'UnitSpec')){
                 if(model.annihilationModeShow() == true){
-                    
+
                       model.send_message('update_commander',
                      {
                          commander: model.scenarioCommanderSpec
@@ -60,7 +60,7 @@ model.selectedCommander = ko.computed(function () {
                         commander: model.scenarioCommanderSpec
                     });
                      _.delay(fixComImage,200)
-                     
+
                      model.selectedCommanderSpec(model.preferredCommander());
                 }
                 return commander;
@@ -71,7 +71,7 @@ model.selectedCommander = ko.computed(function () {
 
     model.selectedCommanderSpec(model.commanders()[index]);
     if(model.commanders()[index] == "/pa/units/commanders/scenario_invincible_com/scenario_invincible_com.json" || model.commanders()[index] == "/pa/units/commanders/scenario_ai_invincible_com/scenario_ai_invincible_com.json"){model.selectedCommanderSpec("/pa/units/commanders/raptor_rallus/raptor_rallus.json");return "/pa/units/commanders/raptor_rallus/raptor_rallus.json"}
- 
+
     return model.commanders()[index];
 });
 
@@ -88,7 +88,7 @@ model.setCommander = function (index) {
     {
         commander: model.selectedCommander()
     });
-    
+
 }
     else{
         console.log("setting special com")
@@ -104,7 +104,7 @@ function fixComImage(){
 
     for(i in model.armies()){
     for(j in model.armies()[i].slots()){
-        
+
         if(model.armies()[i].slots()[j].containsThisPlayer()){
             console.log("fixing commander")
             model.armies()[i].slots()[j].commander(model.selectedCommander())
@@ -131,92 +131,51 @@ function fixComImage(){
         model.commanderPrep()
     }
 
-$('div.section.game_mode').append(
+$(".section.game_mode").after(loadHtml("coui://ui/mods/scenario_lobby/scenario_lobby.html"));
 
-    '<style> .show {display: block;} #scenarioName:hover{font-weight:bold}#scenarioName{border-style: solid solid solid solid} </style>'+
-   '<div class="dropdown">'+
- ' <button onclick="dropdownScenario()" class="dropbtn">Scenarios</button>'+
-  '<div id="dropdownScenario" class="dropdown-content">'+
-   ' <input type="text" placeholder="Search.." id="myInput" onkeyup="filterFunction()">'+
-  
-    '</div>'+
-    '</div> '
-    
-    );
+var populateScenarios = function() {
+    $.getJSON("coui:/mods/scenarios/scenario_list.json").then(function(importedScenarioList) {
+        var scenarioListItemIndex = 0;
+        var loadedScenarios = [];
+        var scenarioSelect = $("#scenario-picker")[0];
 
-$('div.section.game_mode').append(
+        $.each(importedScenarioList.scenarios, function(i, scenarioFilename) {
+            $.getJSON('coui:/mods/scenarios/' + scenarioFilename + '.json')
+                .done(function(importedScenario) {
+                    loadedScenarios.push($("<option>", {
+                        value: scenarioFilename,
+                        text: importedScenario.name || scenarioFilename
+                    }));
+                })
+                .fail(function() {
+                    console.error("Failed to import scenario:", scenarioFilename);
+                })
+                .always(function(importedScenario) {
+                    if (++scenarioListItemIndex === importedScenarioList.scenarios.length) {
+                        $(scenarioSelect).append($("<option>", {
+                            value: "none",
+                            text: "None"
+                        }));
 
-        '<style> .show {display: block;} #scenarioName:hover{font-weight:bold}#scenarioName{border-style: solid solid solid solid} </style>'+
-       '<div class="dropdown">'+
-     '<button onclick="dropdownDescription()" class="dropbtn">Scenario Description</button>'+
-      '<div id="dropdownDescription" class="dropdown-content">'+
-        '</div>'+
-        '</div> '
-        
-        );
+                        $.each(loadedScenarios, function(scenarioIndex, scenario) {
+                            $(scenarioSelect).append(scenario);
+                        });
 
-        
-$('div.section.game_mode').append(
-
-    '<style> .show {display: block;} #scenarioName:hover{font-weight:bold}#scenarioName{border-style: solid solid solid solid} </style>'+
-    '<div class="dropdown">'+
-    ' <button onclick="dropdownSetup()" class="dropbtn">Scenario Setup</button>'+
-    '<div id="dropdownSetup" class="dropdown-content">'+
-    '</div>'+
-    '</div> '
-    
-    );        
-
-
-
-
-
-var gameBar = document.getElementById("game-bar")
-var scenarioName =  document.createElement('div')
-scenarioName.id = "scenario_name"
-scenarioName.innerText = "No scenario has been loaded"
-
-gameBar.appendChild(scenarioName)
-
-
-
-
-
-var populateScenarios = function(){
-
-    $.getJSON('coui:/mods/scenarios/scenario_list.json').then(function(imported) {
-        
-        try{
-    imported.scenarios.push("None")
-
-    var scenarioCount = imported.scenarios.length;
-    var scenarioList = document.getElementById("dropdownScenario");
-
-    for(var i = 0;i<scenarioCount;i++){
-        var scenarioName = imported.scenarios[i]
-        var appendString = document.createElement('div')
-        var scenarioHtml = "<div data-bind='disabled: !model.isGameCreator()'>"+"<div id = 'scenarioName' onclick='model.setScenario("+'"'+scenarioName+'"'+")'>"+scenarioName+"</div></div>"
-        appendString.innerHTML = (scenarioHtml)
-        scenarioList.appendChild(appendString)
-
-    }   
-       
-     }
-     catch(err){console.log(err)}
- 
-     });
-
+                        scenarioSelect.dataset.bind = "enable: canChangeSettings, selectPicker: selectedScenario";
+                        ko.applyBindings(model, scenarioSelect);
+                    }
+                });
+        });
+    });
 }
 
-populateScenarios()
+populateScenarios();
 
 function initialCommanderSet(){
-
     model.send_message('update_commander',
     {
         commander: model.scenarioCommanderSpec
     }); _.delay(fixComImage,200)
-
 }
 
 function setAICommanders(commander){
@@ -226,7 +185,7 @@ function setAICommanders(commander){
         for(slotIndex in army.slots()){
             var slot = army.slots()[slotIndex]
             if(slot.ai() == true && slot.commander() !== commander){
-                
+
             model.send_message('set_ai_commander',
             {
                 id: slot.playerId(),
@@ -238,86 +197,62 @@ function setAICommanders(commander){
 
 }
 
-model.setScenario = function(scenarioName){//there may be issues with people being unreadied, I know that altering the ai's commander does that, so need to check things like that before re setting them
-    if(scenarioName == "None"){document.getElementById("scenario_name").innerHTML = "No scenario has been loaded"}
-    else{
-        document.getElementById("scenario_name").innerHTML= " Scenario "+scenarioName +" is active <br>(please read the setup/description, sandbox is needed)"
-      
-        $.getJSON('coui:/mods/scenarios/'+scenarioName+'.json').then(function(imported) {
-            if(imported.aiComRequired == true){//sets all ai's commanders to the selected com upon scenario load if they are not already
-                setAICommanders(imported.aiCommander)
-                model.scenarioAiCommander = imported.aiCommander
-            }
-            else{
+//there may be issues with people being unreadied, I know that altering the ai's commander does that, so need to check things like that before re setting them
+model.setScenario = function(scenarioFilename) {
+    if (scenarioFilename == "none") {
+        $("#scenarioFilenameWrapper").hide();
+        $("#scenarioSetupWrapper").hide();
+        $("#scenarioDescriptionWrapper").hide();
+    } else {
+        $.getJSON('coui:/mods/scenarios/' + scenarioFilename + '.json').then(function(importedScenario) {
+            // Sets all ai's commanders to the selected com upon scenario load if they are not already
+            if (importedScenario.aiComRequired == true) {
+                setAICommanders(importedScenario.aiCommander)
+                model.scenarioAiCommander = importedScenario.aiCommander
+            } else {
                 model.scenarioAiCommander = undefined
             }
-            if(imported.requireSandbox == true){model.sandbox(true)}
-            if(imported.annihilation == true){model.annihilationModeToggle(); model.annihilationModeShow(true)}
-            if(imported.customCommander !== undefined){model.scenarioCommanderSpec = imported.customCommander; _.delay(initialCommanderSet,1000)}
 
-            var scenarioDescription = document.getElementById("dropdownDescription");
-            var scenarioSetup = document.getElementById("dropdownSetup");
-            
-            if(imported.setup !== undefined){
-                scenarioSetup.innerText = imported.setup
-            }
-            else{
-                scenarioSetup.innerText = 'No setup listed'
+            if (importedScenario.requireSandbox == true) {
+                model.sandbox(true)
             }
 
-            if(imported.description !== undefined){
-                scenarioDescription.innerText = imported.description
-            }
-            else{
-                scenarioDescription.innerText = 'No description listed'
+            if (importedScenario.annihilation == true) {
+                model.annihilationModeToggle();
+                model.annihilationModeShow(true)
             }
 
+            if (importedScenario.customCommander !== undefined) {
+                model.scenarioCommanderSpec = importedScenario.customCommander;
+                _.delay(initialCommanderSet, 1000);
+            }
 
-            scenarioDescription.innerText = imported.description
-        })
+            $("#scenarioFilenameWrapper").show();
+            $("#scenarioFilename").text(scenarioFilename);
+
+            if (importedScenario.setup !== undefined) {
+                $("#scenarioSetupWrapper").show();
+                $("#scenarioSetup").html(importedScenario.description);
+            } else {
+                $("#scenarioSetupWrapper").hide();
+                $("#scenarioSetup").html('');
+            }
+
+            if (importedScenario.description !== undefined) {
+                $("#scenarioDescriptionWrapper").show();
+                $("#scenarioDescription").html(importedScenario.description);
+            } else {
+                $("#scenarioDescriptionWrapper").hide();
+                $("#scenarioDescription").html('');
+            }
+        });
     }
-    model.selectedScenario(scenarioName)
-    if(model.isGameCreator()){_.delay(model.updatePlayersScenario,500)}
 
-}
+    model.selectedScenario(scenarioName);
 
-function dropdownScenario() {
-
-  if(document.getElementById("dropdownScenario").style.display !== "none"){ document.getElementById("dropdownScenario").style.display = "none"}
-  else{if(!model.isGameCreator()){return} document.getElementById("dropdownScenario").style.display = ""}
-  
-}
-function dropdownDescription() {
-
-    if(document.getElementById("dropdownDescription").style.display !== "none"){ document.getElementById("dropdownDescription").style.display = "none"}
-    else{document.getElementById("dropdownDescription").style.display = ""}
-    
-  }
-  function dropdownSetup() {
-
-    if(document.getElementById("dropdownSetup").style.display !== "none"){ document.getElementById("dropdownSetup").style.display = "none"}
-    else{document.getElementById("dropdownSetup").style.display = ""}
-    
-  }
-dropdownScenario()
-dropdownDescription()
-dropdownSetup()
-
-
-function filterFunction() {
-  var input, filter, ul, li, a, i;
-  input = document.getElementById("myInput");
-  filter = input.value.toUpperCase();
-  div = document.getElementById("myDropdown");
-  a = div.getElementsByTagName("div");
-  for (i = 0; i < a.length; i++) {
-    txtValue = a[i].textContent || a[i].innerText;
-    if (txtValue.toUpperCase().indexOf(filter) > -1) {
-      a[i].style.display = "";
-    } else {
-      a[i].style.display = "none";
+    if (model.isGameCreator()) {
+        _.delay(model.updatePlayersScenario, 500);
     }
-  }
 }
 
 //function here to set players com to invincible com if toggle ticked
@@ -332,9 +267,9 @@ model.commanderPrep =function(){
             commander: model.scenarioCommanderSpec
         });
         _.delay(fixComImage,200)
-       
+
     }
-    
+
     else{
 
         model.send_message('update_commander',
@@ -342,7 +277,7 @@ model.commanderPrep =function(){
             commander: model.selectedCommander()
 
             })
-            
+
         }
 
 
@@ -422,7 +357,7 @@ var scenarioHandler = function(msg)
             }
 
             break;
-            
+
         }
     }
 };

--- a/ui/mods/scenario_lobby/scenario_lobby.js
+++ b/ui/mods/scenario_lobby/scenario_lobby.js
@@ -18,7 +18,7 @@ currently does not work if player doesnt modify com selection, won't be an issue
 
 
 
-model.annihilationModeShow = ko.observable(false)    ;
+model.annihilationModeShow = ko.observable(false);
 
 model.selectedScenario = ko.observable(-1).extend({ session: 'selectedScenario' });
 
@@ -232,7 +232,7 @@ model.setScenario = function(scenarioFilename) {
 
             if (importedScenario.setup !== undefined) {
                 $("#scenarioSetupWrapper").show();
-                $("#scenarioSetup").html(importedScenario.description);
+                $("#scenarioSetup").html(importedScenario.setup);
             } else {
                 $("#scenarioSetupWrapper").hide();
                 $("#scenarioSetup").html('');
@@ -248,7 +248,7 @@ model.setScenario = function(scenarioFilename) {
         });
     }
 
-    model.selectedScenario(scenarioName);
+    model.selectedScenario(scenarioFilename);
 
     if (model.isGameCreator()) {
         _.delay(model.updatePlayersScenario, 500);

--- a/ui/mods/scenarios/bug_horde_expert.json
+++ b/ui/mods/scenarios/bug_horde_expert.json
@@ -1,7 +1,7 @@
 {
     "name": "Bug Mode",
     "description": "An Expert variation of bug wave defense. You start with units and a control tower(zapper) that prevents bugs from spawning near you. exponentially larger waves of bugs will assault you over time.",
-    "setup":"There needs to be an ai,the last one in the lobby will act as the bugs. this ai needs to have the scenario ai commander(DO NOT SELECT) selected for it. This mode should only be played on single planet maps",
+    "setup":"<ul><li>There needs to be an ai - the last one in the lobby will act as the bugs</li><li>The ai needs to have the scenario ai commander (DO NOT SELECT) selected for it.</li><li>This mode should only be played on single planet maps.</li>",
     "aiComRequired":true,
     "aiCommander":"/pa/units/commanders/scenario_ai_invincible_com/scenario_ai_invincible_com.json",
     "scenarioID": 2,
@@ -66,12 +66,12 @@
             "scalingNumber":0.3,
             "scalingRatio":0.2,
             "waveInterval":120,
-      
+
             "unitValues":[
 
-                
+
             {
-                
+
                 "waveChance":0.6,
 
                 "spitters":{
@@ -80,7 +80,7 @@
                         ["/pa/units/land/bug_scout/bug_scout.json",2,80],
                         ["/pa/units/land/bug_scorcher/bug_scorcher.json",40,400],
                         ["/pa/units/land/bug_basilisk/bug_basilisk.json",300,300000]
-                    
+
                     ]
                 },
                 "melee":{
@@ -102,14 +102,14 @@
                 }
             },
             {
-                
+
                 "waveChance":0.4,
 
                 "runners":{
                     "value":1,
                     "units":[
                          ["/pa/units/land/bug_runner/runner.json",20,50000000]
-                      
+
                          ]
 
                 }
@@ -160,7 +160,7 @@
             "scalingNumber":0.3,
             "scalingRatio":0.1,
             "waveInterval":40,
-      
+
             "unitValues":[{
 
                 "waveChance":1.0,
@@ -187,7 +187,7 @@
                          ["/pa/units/land/bug_warrior_big/bug_warrior_big.json",300,100000]
                          ]
                 }
-               
+
 
             }],
             "startingObjective": true,
@@ -292,7 +292,7 @@
             "time":0,
             "startingObjective": true,
             "successTriggers": [
-        
+
                "starting zappers","starting units"
             ],
             "failureTriggers": [
@@ -306,11 +306,11 @@
             ]
         }
     ],
-    
-      
+
+
     "triggers": [
- 
-        
+
+
             {
                 "name": "starting zappers",
                 "id": 3,
@@ -320,7 +320,7 @@
                 "special":"unit type",
                 "unitType":"UNITTYPE_Commander",
                 "newUnitName":[["/pa/units/land/control_tower/control_tower.json",1]]
-                
+
             },
             {
                 "name": "starting units",
@@ -331,7 +331,7 @@
                 "special":"unit type",
                 "unitType":"UNITTYPE_Commander",
                 "newUnitName":[["/pa/units/land/fabrication_vehicle/fabrication_vehicle.json",3],["/pa/units/land/attack_vehicle/attack_vehicle.json",20],["/pa/units/land/energy_plant/energy_plant.json",2]]
-                
+
             },
 			{
                 "name": "reward1",
@@ -342,7 +342,7 @@
                 "special":"unit type",
                 "unitType":"UNITTYPE_Shield",
                 "newUnitName":[["/pa/units/sea/hover_ship/hover_ship.json",1]]
-                
+
             },
             {
                 "name": "reward2",
@@ -353,7 +353,7 @@
                 "special":"unit type",
                 "unitType":"UNITTYPE_Shield",
                 "newUnitName":[["/pa/units/sea/hover_ship/hover_ship.json",3]]
-                
+
             },
             {
                 "name": "win",
@@ -361,8 +361,8 @@
                 "delay": 0,
                 "planet":0,
                 "type": "kill_all_invincible_ai"
-               
+
             }
-        
+
     ]
 }


### PR DESCRIPTION
- You can use ordered and unordered lists via HTML tags in setup and description!
- Only those with access to change the scenario (`canChangeSettings`) can see the setup info (untested, but probably works).
- Description + setup info are a bit long, so make the left column scroll on small screens. It's be great for others with 1920x1080 or smaller screens to test? They could have "read more >" type buttons with modals, but they're not really needed for now(?)
 
![image](https://user-images.githubusercontent.com/462459/125179342-b8da3280-e1e5-11eb-8fba-c63eee69e0f7.png)
